### PR TITLE
Updated link to help

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ This extension uses a class derived from [asciimath2tex](https://github.com/chri
 
 ## Developer
 
-Giovanni Salmeri. [Get help](https://github.com/GiovanniSalmeri/yellow-music/issues).
+Giovanni Salmeri. [Get help](https://datenstrom.se/yellow/help/).


### PR DESCRIPTION
In an attempt to unify [extensions](https://github.com/datenstrom/yellow-extensions), I would like to unify the documentation and suggest changing the "Get help" link everywhere. Since I had to pick one of your repositories, I picked my favourite one. 😁